### PR TITLE
fix: resolve issues #12-16 (tag fallback, auto-select, scroll, unrecommend, mobile UI)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -12,6 +12,8 @@
 - 日英バイリンガルタグ——日英表示切り替え・手動入力時の自動翻訳
 - AI 要約自動生成（バックグラウンドジョブ、日本語箇条書き）
 - AI タグ提案（AI 要約から生成）
+- 記事単位の LLM チャットパネル（必要に応じて DuckDuckGo Web 検索を併用、トリガー: 「検索」「最新」「調べて」など）
+- IDF 重み付き「Recommend」ビュー（高カバー率タグを自動除外）
 - OPML インポート / エクスポート
 - Saved 記事インポート（Inoreader / Google Reader JSON 形式）
 - キーボードショートカット（`j`/`k` ナビ、`s` 保管、`/` 検索）
@@ -27,6 +29,7 @@
 | フィード解析 | feedparser, trafilatura |
 | スケジューラ | APScheduler 3.x |
 | AI（オプション） | mlx-lm.server（ローカル LLM、OpenAI 互換） |
+| Web 検索（オプション） | DuckDuckGo（`ddgs`） |
 
 ## 前提条件
 
@@ -74,6 +77,11 @@ LLM サーバーが利用可能な場合、SnoReader は以下を自動実行す
 - 記事の日本語箇条書き要約をバックグラウンドで生成（優先順：Saved > 未読 > 既読）
 - AI 要約をもとにタグを提案
 - 手動入力された日本語タグを英語に自動翻訳
+- リーダーペイン下部のチャットパネルで記事に関する自由質問を受け付け（セッション内履歴のみ、記事切替でクリア）
+
+### チャット Web 検索
+
+チャット入力にトリガーワード（`検索`、`調べて`、`search`、`最新`、`latest`、または「今…？」疑問文）が含まれる場合、バックエンドが `ddgs` 経由で DuckDuckGo 検索を実行し、上位 3 件を LLM コンテキストに注入、回答と合わせてソースリンクを返す。検索失敗・タイムアウト時は記事のみをコンテキストにフォールバックする。
 
 ## 本番デプロイ
 
@@ -123,7 +131,8 @@ snoreader/
 │       ├── services/
 │       │   ├── feed_fetcher.py   #   RSS 取得・パース
 │       │   ├── content_extractor.py # trafilatura 本文抽出
-│       │   └── scheduler.py      #   APScheduler: フィード更新 + AI 要約
+│       │   ├── scheduler.py      #   APScheduler: フィード更新 + AI 要約
+│       │   └── web_search.py     #   チャット用 DuckDuckGo 検索ヘルパー
 │       └── ai/
 │           ├── llm_client.py     #   OpenAI 互換 LLM クライアント
 │           ├── summarizer.py     #   記事要約
@@ -136,7 +145,7 @@ snoreader/
 │       ├── hooks/                # TanStack Query フック
 │       └── components/
 │           ├── layout/FeedSidebar.tsx
-│           └── articles/{ArticleList,ArticleCard,ArticleReader}.tsx
+│           └── articles/{ArticleList,ArticleCard,ArticleReader,ArticleChatPanel}.tsx
 ├── data/                         # SQLite DB（git 管理外）
 ├── certs/                        # TLS 証明書（git 管理外）
 └── Makefile

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # SnoReader
 
+[日本語版 README](README.ja.md)
+
 A self-hosted RSS reader — access from multiple devices on your LAN via browser.
 
 ## Features
@@ -12,6 +14,8 @@ A self-hosted RSS reader — access from multiple devices on your LAN via browse
 - Bilingual tagging — English/Japanese display toggle, manual input with auto-translation
 - AI summary auto-generation (background job, Japanese bullet points)
 - AI tag suggestions (generated from AI summary)
+- Article-scoped LLM chat panel with optional DuckDuckGo web search (triggered by keywords like "検索", "最新", "調べて")
+- IDF-weighted "Recommend" view with automatic exclusion of high-coverage tags
 - OPML import / export
 - Saved articles import (Inoreader / Google Reader JSON format)
 - Keyboard shortcuts (`j`/`k` navigation, `s` save, `/` search)
@@ -27,6 +31,7 @@ A self-hosted RSS reader — access from multiple devices on your LAN via browse
 | Feed parsing | feedparser, trafilatura |
 | Scheduler | APScheduler 3.x |
 | AI (optional) | mlx-lm.server (local LLM, OpenAI-compatible) |
+| Web search (optional) | DuckDuckGo via `ddgs` |
 
 ## Prerequisites
 
@@ -74,6 +79,11 @@ When the LLM server is available, SnoReader:
 - Auto-generates Japanese bullet-point summaries for articles (background job, priority: Saved > Unread > Read)
 - Suggests tags based on the AI summary
 - Auto-translates manually entered Japanese tags into English
+- Enables a chat panel at the bottom of the reader pane for free-form questions about the current article (session-only history, cleared on article switch)
+
+### Chat web search
+
+When a chat message contains a trigger word (`検索`, `調べて`, `search`, `最新`, `latest`, or a "今…？" question), the backend runs a DuckDuckGo search via `ddgs`, injects the top 3 results into the LLM context, and returns source links alongside the reply. Search failures or timeouts fall back silently to article-only answers.
 
 ## Production
 
@@ -123,7 +133,8 @@ snoreader/
 │       ├── services/
 │       │   ├── feed_fetcher.py   #   RSS fetch + parse
 │       │   ├── content_extractor.py # trafilatura article extraction
-│       │   └── scheduler.py      #   APScheduler: feed refresh + AI summarization
+│       │   ├── scheduler.py      #   APScheduler: feed refresh + AI summarization
+│       │   └── web_search.py     #   DuckDuckGo search helper for chat
 │       └── ai/
 │           ├── llm_client.py     #   OpenAI-compatible LLM client
 │           ├── summarizer.py     #   article summarization
@@ -136,7 +147,7 @@ snoreader/
 │       ├── hooks/                # TanStack Query hooks
 │       └── components/
 │           ├── layout/FeedSidebar.tsx
-│           └── articles/{ArticleList,ArticleCard,ArticleReader}.tsx
+│           └── articles/{ArticleList,ArticleCard,ArticleReader,ArticleChatPanel}.tsx
 ├── data/                         # SQLite DB (gitignored)
 ├── certs/                        # TLS certificates (gitignored)
 └── Makefile

--- a/backend/app/routers/articles.py
+++ b/backend/app/routers/articles.py
@@ -162,6 +162,63 @@ async def get_recommended_articles(
     return PaginatedArticles(items=items, total=total, offset=offset, limit=limit)
 
 
+@router.get("/articles/unrecommended", response_model=PaginatedArticles)
+async def get_unrecommended_articles(
+    sort: str = Query("date", pattern="^(date)$"),
+    order: str = Query("desc", pattern="^(asc|desc)$"),
+    offset: int = Query(0, ge=0),
+    limit: int = Query(50, ge=1, le=200),
+    session: AsyncSession = Depends(get_session),
+):
+    """Return unread articles with zero overlap with saved article tags."""
+    import json as _json
+
+    freq_stmt = (
+        select(Tag.name)
+        .join(ArticleTag, Tag.id == ArticleTag.tag_id)
+        .join(Article, ArticleTag.article_id == Article.id)
+        .where(Article.is_saved == True)  # noqa: E712
+        .distinct()
+    )
+    saved_tag_names: set[str] = set((await session.execute(freq_stmt)).scalars())
+
+    stmt = (
+        select(Article, Feed.title.label("feed_title"))
+        .join(Feed)
+        .where(
+            Article.is_read == False,  # noqa: E712
+            Article.is_saved == False,  # noqa: E712
+            Article.tag_suggestions.isnot(None),
+        )
+    )
+    rows = (await session.execute(stmt)).all()
+
+    def _pub_ts(a: Article) -> float:
+        try:
+            return datetime.fromisoformat(a.published_at).timestamp() if a.published_at else 0.0
+        except (ValueError, TypeError):
+            return 0.0
+
+    unmatched: list[tuple[Article, str]] = []
+    for row in rows:
+        article, feed_title = row[0], row[1]
+        suggestions = set(_json.loads(article.tag_suggestions))
+        if not suggestions & saved_tag_names:
+            unmatched.append((article, feed_title))
+
+    unmatched.sort(key=lambda x: -_pub_ts(x[0]) if order == "desc" else _pub_ts(x[0]))
+
+    total = len(unmatched)
+    page = unmatched[offset: offset + limit]
+
+    items = []
+    for article, feed_title in page:
+        out = ArticleOut.model_validate(article)
+        out.feed_title = feed_title
+        items.append(out)
+    return PaginatedArticles(items=items, total=total, offset=offset, limit=limit)
+
+
 @router.get("/articles/{article_id}", response_model=ArticleDetail)
 async def get_article(article_id: int, session: AsyncSession = Depends(get_session)):
     article = await session.get(Article, article_id)

--- a/backend/app/routers/tags.py
+++ b/backend/app/routers/tags.py
@@ -75,12 +75,20 @@ async def rename_tag(tag_id: int, body: TagUpdate, session: AsyncSession = Depen
         en_name = input_name.lower()
         ja_name: str | None = None
     else:
-        from app.ai.tagger import translate_to_english
-        from app.ai.task_queue import PRIORITY_FOREGROUND
         ja_name = input_name
-        en_name = await translate_to_english(input_name, priority=PRIORITY_FOREGROUND)
-        if not en_name:
-            raise HTTPException(status_code=503, detail="LLM unavailable — cannot translate Japanese tag to English. Please enter an English tag name.")
+        existing_ja = (await session.execute(
+            select(Tag).where(Tag.name_ja == ja_name, Tag.id != tag_id)
+        )).scalar_one_or_none()
+        if existing_ja:
+            en_name = existing_ja.name
+        else:
+            from app.ai.tagger import translate_to_english
+            from app.ai.task_queue import PRIORITY_FOREGROUND
+            en_name = await translate_to_english(input_name, priority=PRIORITY_FOREGROUND)
+            if not en_name:
+                import re
+                slug = re.sub(r"[^\w]", "", input_name, flags=re.UNICODE).lower() or input_name
+                en_name = slug
 
     # 正規化後に同名なら何もしない
     if en_name == tag.name and (not ja_name or ja_name == tag.name_ja):
@@ -158,13 +166,22 @@ async def add_tag_to_article(
         en_name = input_name.lower()
         ja_name = body.name_ja
     else:
-        # Japanese input: generate English name via LLM and store as name
-        from app.ai.tagger import translate_to_english
-        from app.ai.task_queue import PRIORITY_FOREGROUND
         ja_name = input_name
-        en_name = await translate_to_english(input_name, priority=PRIORITY_FOREGROUND)
-        if not en_name:
-            raise HTTPException(status_code=503, detail="LLM unavailable — cannot translate Japanese tag to English. Please enter an English tag name.")
+        # First check if a tag with this name_ja already exists — no LLM needed
+        existing_ja = (await session.execute(
+            select(Tag).where(Tag.name_ja == ja_name)
+        )).scalar_one_or_none()
+        if existing_ja:
+            en_name = existing_ja.name
+        else:
+            from app.ai.tagger import translate_to_english
+            from app.ai.task_queue import PRIORITY_FOREGROUND
+            en_name = await translate_to_english(input_name, priority=PRIORITY_FOREGROUND)
+            if not en_name:
+                # LLM unavailable: store Japanese as-is using a slugified key
+                import re
+                slug = re.sub(r"[^\w]", "", input_name, flags=re.UNICODE).lower() or input_name
+                en_name = slug
 
     result = await session.execute(select(Tag).where(Tag.name == en_name))
     tag = result.scalar_one_or_none()

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -47,6 +47,11 @@ export function getArticles(
     if (filters.order) params.set('order', filters.order);
     return fetchJSON(`${BASE}/articles/recommended?${params}`);
   }
+  if (filters.unrecommended) {
+    const params = new URLSearchParams({ offset: String(offset), limit: String(limit) });
+    if (filters.order) params.set('order', filters.order);
+    return fetchJSON(`${BASE}/articles/unrecommended?${params}`);
+  }
   const params = new URLSearchParams();
   if (filters.feed_id != null) params.set('feed_id', String(filters.feed_id));
   if (filters.is_read != null) params.set('is_read', String(filters.is_read));

--- a/frontend/src/components/articles/ArticleChatPanel.tsx
+++ b/frontend/src/components/articles/ArticleChatPanel.tsx
@@ -86,7 +86,7 @@ export function ArticleChatPanel({ articleId }: Props) {
   };
 
   return (
-    <div className="sticky bottom-0 bg-white dark:bg-gray-950 border-t border-gray-200 dark:border-gray-800">
+    <div className="sticky bottom-0 bg-white dark:bg-gray-950 border-t border-gray-200 dark:border-gray-800 overflow-hidden">
       <div className="max-w-3xl mx-auto">
         {(history.length > 0 || chat.isPending || error) && (
           <div ref={historyRef} className="max-h-[20vh] overflow-y-auto p-3 space-y-2 text-sm">
@@ -158,7 +158,7 @@ export function ArticleChatPanel({ articleId }: Props) {
           <button
             type="submit"
             disabled={chat.isPending || !input.trim()}
-            className="px-3 py-2 text-sm rounded-md bg-blue-500 text-white hover:bg-blue-600 disabled:opacity-40 disabled:cursor-not-allowed"
+            className="shrink-0 px-3 py-2 text-sm rounded-md bg-blue-500 text-white hover:bg-blue-600 disabled:opacity-40 disabled:cursor-not-allowed"
           >
             Send
           </button>

--- a/frontend/src/components/articles/ArticleList.tsx
+++ b/frontend/src/components/articles/ArticleList.tsx
@@ -66,11 +66,21 @@ export function ArticleList({ filters, onFilterChange, tagLang }: Props) {
     return [pinned, ...articles];
   }, [articles, selectedId]);
 
-  // Reset scroll on filter/search change and clear pinned article
+  // Reset scroll on filter/search change, clear pinned article, and auto-select first article
   useEffect(() => {
     listRef.current?.scrollTo(0, 0);
     pinnedArticleRef.current = null;
+    setSelectedId(null);
   }, [filters, searchQuery]);
+
+  // Auto-select the first article when the article list loads after a filter change
+  useEffect(() => {
+    if (selectedId != null) return;
+    if (isLoading) return;
+    if (displayArticles.length > 0) {
+      setSelectedId(displayArticles[0].id);
+    }
+  }, [displayArticles, isLoading, selectedId]);
 
   // Infinite scroll via IntersectionObserver
   useEffect(() => {
@@ -182,7 +192,7 @@ export function ArticleList({ filters, onFilterChange, tagLang }: Props) {
             className="w-full px-2 py-1.5 text-sm border rounded dark:bg-gray-800 dark:border-gray-600"
           />
           <div className="flex items-center gap-1.5 flex-wrap">
-            {!filters.recommended && !filters.is_saved && (
+            {!filters.recommended && !filters.unrecommended && !filters.is_saved && (
               <>
                 <button onClick={() => onFilterChange({ ...filters, is_read: false })} className={filterBtnClass(filters.is_read === false)}>Unread</button>
                 <button onClick={() => onFilterChange({ ...filters, is_read: undefined })} className={filterBtnClass(filters.is_read === undefined)}>All</button>
@@ -255,6 +265,7 @@ export function ArticleList({ filters, onFilterChange, tagLang }: Props) {
               ← Back
             </button>
             <ArticleReader
+              key={selectedId}
               articleId={selectedId}
               tagLang={tagLang}
               aiAvailable={aiAvailable}

--- a/frontend/src/components/articles/ArticleReader.tsx
+++ b/frontend/src/components/articles/ArticleReader.tsx
@@ -191,7 +191,7 @@ export function ArticleReader({ articleId, tagLang, aiAvailable, onPrev, onNext 
 
   return (
     <div ref={containerRef} className="h-screen overflow-y-auto pt-12 md:pt-0">
-      <article className="max-w-3xl mx-auto p-6">
+      <article className="relative max-w-3xl mx-auto p-6">
         <header className="mb-6">
           <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100 leading-tight mb-2">
             <a
@@ -349,11 +349,9 @@ export function ArticleReader({ articleId, tagLang, aiAvailable, onPrev, onNext 
         )}
       </article>
 
-      {aiAvailable && <ArticleChatPanel articleId={article.id} />}
-
-      {/* Floating prev/next buttons (mobile only) */}
+      {/* Prev/next buttons — bottom-right of article body (mobile only, above chat panel) */}
       {(onPrev || onNext) && (
-        <div className="md:hidden fixed bottom-6 right-4 flex flex-col gap-2 z-30">
+        <div className="md:hidden flex justify-end gap-2 mt-6 pb-2">
           <button
             onClick={onPrev}
             disabled={!onPrev}
@@ -372,6 +370,8 @@ export function ArticleReader({ articleId, tagLang, aiAvailable, onPrev, onNext 
           </button>
         </div>
       )}
+
+      {aiAvailable && <ArticleChatPanel articleId={article.id} />}
     </div>
   );
 }

--- a/frontend/src/components/layout/FeedSidebar.tsx
+++ b/frontend/src/components/layout/FeedSidebar.tsx
@@ -1,7 +1,7 @@
 import { useRef, useState } from 'react';
 import { Spinner } from '../common/Spinner';
 import { useFeeds, useCreateFeed, useDeleteFeed, useRefreshFeed, useImportOpml, useImportArticles } from '../../hooks/useFeeds';
-import { useRecommendedCount, useSavedCount, useAiStatus } from '../../hooks/useArticles';
+import { useRecommendedCount, useUnrecommendedCount, useSavedCount, useAiStatus } from '../../hooks/useArticles';
 import { useTags, useRenameTag, useBulkDeleteTags, useAiTagSaved, useFillTagTranslations } from '../../hooks/useTags';
 import { opmlExportUrl } from '../../api/client';
 import type { ArticleFilters } from '../../types';
@@ -36,6 +36,7 @@ export function FeedSidebar({ filters, onFilterChange, tagLang, onToggleTagLang,
 
   const totalUnread = feeds?.reduce((s, f) => s + f.unread_count, 0) ?? 0;
   const { data: recommendedCount } = useRecommendedCount();
+  const { data: unrecommendedCount } = useUnrecommendedCount();
   const { data: savedCount } = useSavedCount();
   const { data: aiStatus } = useAiStatus();
 
@@ -83,6 +84,21 @@ export function FeedSidebar({ filters, onFilterChange, tagLang, onToggleTagLang,
       </div>
 
       <nav className="flex-1 p-2 space-y-0.5">
+        {/* All articles */}
+        <button
+          onClick={() => onFilterChange({ ...filters, feed_id: undefined, is_saved: undefined, tag_id: undefined, recommended: undefined, unrecommended: undefined })}
+          className={`w-full text-left px-3 py-2 rounded text-sm flex justify-between items-center hover:bg-gray-200 dark:hover:bg-gray-800 ${
+            filters.feed_id == null && filters.is_saved == null && filters.tag_id == null && !filters.recommended && !filters.unrecommended ? 'bg-gray-200 dark:bg-gray-800 font-semibold' : ''
+          }`}
+        >
+          <span>All</span>
+          {totalUnread > 0 && (
+            <span className="text-xs bg-blue-500 text-white rounded-full px-1.5 py-0.5 min-w-[20px] text-center">
+              {totalUnread}
+            </span>
+          )}
+        </button>
+
         {/* Recommended */}
         <button
           onClick={() => onFilterChange({ recommended: true })}
@@ -98,24 +114,22 @@ export function FeedSidebar({ filters, onFilterChange, tagLang, onToggleTagLang,
           )}
         </button>
 
-        {/* All articles */}
+        {/* Unrecommended */}
         <button
-          onClick={() => onFilterChange({ ...filters, feed_id: undefined, is_saved: undefined, tag_id: undefined, recommended: undefined })}
+          onClick={() => onFilterChange({ unrecommended: true })}
           className={`w-full text-left px-3 py-2 rounded text-sm flex justify-between items-center hover:bg-gray-200 dark:hover:bg-gray-800 ${
-            filters.feed_id == null && filters.is_saved == null && filters.tag_id == null && !filters.recommended ? 'bg-gray-200 dark:bg-gray-800 font-semibold' : ''
+            filters.unrecommended ? 'bg-gray-200 dark:bg-gray-800 font-semibold' : ''
           }`}
         >
-          <span>All</span>
-          {totalUnread > 0 && (
-            <span className="text-xs bg-blue-500 text-white rounded-full px-1.5 py-0.5 min-w-[20px] text-center">
-              {totalUnread}
-            </span>
+          <span>✧ Unrecommend</span>
+          {!!unrecommendedCount && (
+            <span className="text-xs text-gray-400 tabular-nums">{unrecommendedCount}</span>
           )}
         </button>
 
         {/* Saved */}
         <button
-          onClick={() => onFilterChange({ ...filters, feed_id: undefined, is_saved: true, is_read: undefined, tag_id: undefined, recommended: undefined })}
+          onClick={() => onFilterChange({ ...filters, feed_id: undefined, is_saved: true, is_read: undefined, tag_id: undefined, recommended: undefined, unrecommended: undefined })}
           className={`w-full text-left px-3 py-2 rounded text-sm flex justify-between items-center hover:bg-gray-200 dark:hover:bg-gray-800 ${
             filters.is_saved === true && filters.tag_id == null ? 'bg-gray-200 dark:bg-gray-800 font-semibold' : ''
           }`}
@@ -231,6 +245,7 @@ export function FeedSidebar({ filters, onFilterChange, tagLang, onToggleTagLang,
                       is_saved: undefined,
                       tag_id: filters.tag_id === tag.id ? undefined : tag.id,
                       recommended: undefined,
+                      unrecommended: undefined,
                     })}
                     className={`px-1.5 py-0.5 rounded text-xs hover:bg-gray-200 dark:hover:bg-gray-800 ${
                       filters.tag_id === tag.id
@@ -253,7 +268,7 @@ export function FeedSidebar({ filters, onFilterChange, tagLang, onToggleTagLang,
         {feeds?.map((feed) => (
           <div key={feed.id} className="group flex items-center">
             <button
-              onClick={() => onFilterChange({ ...filters, feed_id: feed.id, is_saved: undefined, recommended: undefined })}
+              onClick={() => onFilterChange({ ...filters, feed_id: feed.id, is_saved: undefined, recommended: undefined, unrecommended: undefined })}
               className={`flex-1 text-left px-3 py-1.5 rounded text-sm truncate flex items-center gap-2 hover:bg-gray-200 dark:hover:bg-gray-800 ${
                 filters.feed_id === feed.id ? 'bg-gray-200 dark:bg-gray-800 font-semibold' : ''
               }`}

--- a/frontend/src/hooks/useArticles.ts
+++ b/frontend/src/hooks/useArticles.ts
@@ -107,6 +107,14 @@ export function useRecommendedCount() {
   });
 }
 
+export function useUnrecommendedCount() {
+  return useQuery({
+    queryKey: ['unrecommended-count'],
+    queryFn: () => api.getArticles({ unrecommended: true }, 0, 1).then(r => r.total),
+    staleTime: 60_000,
+  });
+}
+
 export function useSavedCount() {
   return useQuery({
     queryKey: ['saved-count'],

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -63,6 +63,7 @@ export interface ArticleFilters {
   sort?: string;
   order?: string;
   recommended?: boolean;
+  unrecommended?: boolean;
 }
 
 export interface ChatMessage {


### PR DESCRIPTION
## Summary

- **#12** Japanese tag input no longer returns 503 when LLM is unavailable. Falls back to `name_ja` lookup on existing tags, then a Unicode-slug key. LLM translation still runs in the background when available.
- **#13** Switching sidebar filter (feed, tag, All/Recommend/Saved) now auto-selects the first article in the new list; an empty list clears the reader pane.
- **#14** Added `key={selectedId}` to `ArticleReader` so the component fully remounts on article change, guaranteeing scroll-to-top even when React Query returns cached data instantly.
- **#15** New `Unrecommend` filter — shows unread/unsaved articles whose tag suggestions have zero overlap with saved-article tags. New backend endpoint `GET /api/articles/unrecommended`. Sidebar order: **All / Recommend / Unrecommend / Saved**.
- **#16** Mobile layout: nav buttons (↑/↓) moved inside the article body area just above the chat panel so they no longer float over the Send button. Added `overflow-hidden` and `shrink-0` to the chat panel so it never clips off-screen.

## Changed files

| File | Change |
|---|---|
| `backend/app/routers/articles.py` | Add `/articles/unrecommended` endpoint |
| `backend/app/routers/tags.py` | Japanese tag fallback (name_ja lookup + slug) |
| `frontend/src/types/index.ts` | Add `unrecommended` to `ArticleFilters` |
| `frontend/src/api/client.ts` | Route `unrecommended` to new endpoint |
| `frontend/src/hooks/useArticles.ts` | Add `useUnrecommendedCount` hook |
| `frontend/src/components/layout/FeedSidebar.tsx` | New order + Unrecommend button |
| `frontend/src/components/articles/ArticleList.tsx` | Auto-select first article on filter change, `key` on reader |
| `frontend/src/components/articles/ArticleReader.tsx` | Nav buttons moved above chat panel |
| `frontend/src/components/articles/ArticleChatPanel.tsx` | `overflow-hidden`, `shrink-0` on Send button |

## Test plan

- [ ] Add Japanese tag when LLM is offline → tag is created with slug key, no 503
- [ ] Same Japanese tag already exists (via `name_ja`) → reuses existing tag without LLM
- [ ] Click a feed in sidebar → first article auto-selected in reader
- [ ] Navigate to an empty feed → reader pane clears
- [ ] Navigate j/k between articles → reader always scrolls to top
- [ ] Sidebar shows All / Recommend / Unrecommend / Saved in that order
- [ ] Click Unrecommend → only articles with no saved-tag overlap appear
- [ ] Mobile (375px): ↑/↓ buttons appear below article body, above chat input; no overlap
- [ ] Mobile: AI chat panel fully visible, no horizontal clipping